### PR TITLE
fix auth object failing to stringify

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -36,7 +36,14 @@ async function getAuthorization() {
         return await showAuthModal();
     } else {
         const obj = JSON.parse(localStorage.getItem("auth"));
-        return buildAuthorization(obj);
+        if (obj.apikey) {
+            // Backwards compatibility with old auth object
+            obj.webApiKey = obj.apikey
+        }
+        obj.toString = function() {
+            return `z=${this.username}&y=${this.webApiKey}`;
+        }
+        return obj;
     }
 }
 


### PR DESCRIPTION
- Add backwards compatibility so users don't have to re-enter their auth token
- Fix issue with auth object stringifying to [object Object]

Working on testing now to make sure issue is resolved.